### PR TITLE
Fix: Remove redundant google_search_tool initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,6 @@ safety_settings = [
     ),
 ]
 
-google_search_tool = Tool(google_search=GoogleSearch())
 
 
 def run_llm_inference(
@@ -61,7 +60,6 @@ def run_llm_inference_with_grounding(
     # print(f"   System Prompt: {system_prompt}")
     # print(f"   User Prompt: {prompt[:250]}...")
 
-    google_search_tool = Tool(google_search=GoogleSearch())
 
     response = client.models.generate_content(
         model=model_name,


### PR DESCRIPTION
Resolves #42

The `google_search_tool` was being redundantly initialized inside the `run_llm_inference_with_grounding` function. This commit removes that redundant initialization, as the `Tool` object is already defined globally at the module level, improving efficiency.